### PR TITLE
fix: update plain background according to app's theme

### DIFF
--- a/app/src/main/java/app/cclauncher/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/app/cclauncher/ui/screens/SettingsScreen.kt
@@ -279,7 +279,7 @@ fun SettingsScreen(
             currentProperty?.let { prop ->
                 when (prop.name) {
                     "plainWallpaper" -> {
-                        setPlainWallpaperByTheme(context, appTheme = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+                        setPlainWallpaperByTheme(context, appTheme = uiState.appTheme)
                         showingDialog = null
                     }
                 }


### PR DESCRIPTION
fix #84 

This happens because when updating the plain wallpaper, it always refers the system-level dark mode setting and modifying it in the app-level settings does not work.

To verify it works, now go app settings, setting "Theme" and then click "Set Plain Wallpaper" will produce the expected background color.